### PR TITLE
fix(image_to_avatar): run holistic pose before background removal

### DIFF
--- a/human_avatar/image_to_avatar.py
+++ b/human_avatar/image_to_avatar.py
@@ -132,12 +132,14 @@ def image_to_avatar(image: Image, include_pose=True):
     if not sfw:
         raise ValueError("Image is not safe for work")
 
+    # before background removal, so a holistic detection failure costs no RMBG time
+    full_pose = extract_full_pose(image) if include_pose else None
+
     masked_image = remove_image_background(cropped_image)
     # paste on green background
     green_screen = Image.new("RGB", masked_image.size, "green")
     masked_image = Image.composite(masked_image, green_screen, masked_image)
 
-    full_pose = extract_full_pose(image) if include_pose else None
     return cropped_image, masked_image, full_pose
 
 


### PR DESCRIPTION
Follow-up to #6, addressing [Cursor Bugbot's post-merge comment](https://github.com/sign/image-to-human-avatar/pull/6#discussion_r3552597549): with the default `include_pose=True`, `extract_full_pose` ran only after `remove_image_background`, so in the rare case where BlazePose finds a person that holistic later misses, the request paid the multi-second RMBG pass before failing with `No pose detected`.

`extract_full_pose` now runs right before background removal — still after the cheap size and NSFW gates, so rejected images never pay the holistic cost. On successful requests the total work is identical; outputs are unchanged.

Verified: default flow end-to-end on the flux example (crop, mask, and 586-point pose produced), `ruff check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single pipeline reorder with no API or output changes on success; only improves failure-path latency.
> 
> **Overview**
> Reorders **`image_to_avatar`** so **`extract_full_pose`** runs immediately after the crop-size and NSFW checks and **before** **`remove_image_background`**, instead of after RMBG and green-screen compositing.
> 
> When **`include_pose=True`** (default) and holistic fails with “No pose detected” after BlazePose already found shoulders, the pipeline no longer spends time on the heavy RMBG pass first. Successful requests still run the same steps in a different order only for pose vs. mask; returned crop, mask, and pose are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35da84912a7e0046681d50f6f699e19da8cf1211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->